### PR TITLE
Add --append flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "saml2aws-auto"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saml2aws-auto"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Jan Christopehrsen <jan@ruken.pw>"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download the release for your platform and make sure `saml2aws-auto` is in your 
 ## Usage
 
 ```plain
-saml2aws-auto 1.0.0
+saml2aws-auto 1.1.0
 Jan Christophersen <jan@ruken.pw>
 A wrapper around saml2aws allowing you to refresh multiple AWS credentials at the same time
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,5 +1,5 @@
 name: saml2aws-auto
-version: "1.0.0"
+version: "1.1.0"
 author: Jan Christophersen <jan@ruken.pw>
 about: A wrapper around saml2aws allowing you to refresh multiple AWS credentials at the same time
 settings:
@@ -59,6 +59,9 @@ subcommands:
             takes_value: true
             required: true
             help: Name of the group
+        - append:
+            long: append
+            help: When set, existing accounts in the group will not be removed. New accounts will be appended to the list
         - business_unit:
             long: business-unit
             help: Uses the BusinessUnit of your AWS accounts as a group, e.g. my-unit when having accounts my-unit-dev, my-unit-int, ...


### PR DESCRIPTION
This flag can be used with "groups add" to prevent removing accounts
that are already present in an existing group.

Closes #1.