### PR TITLE
Fix expecting an existing AWS credentials file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "saml2aws-auto"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1068,6 +1068,7 @@ dependencies = [
  "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_sts 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-ini 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scraper 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saml2aws-auto"
-version = "1.2.0"
+version = "1.2.1"
 description = "A simple management tool for AWS credentials when using Keycloak with SAML"
 license-file = "LICENSE"
 authors = ["Jan Christopehrsen <jan@ruken.pw>"]
@@ -21,4 +21,5 @@ cookie = "0.10"
 base64 = "~0.6.0"
 rusoto_core = "0.32.0"
 rusoto_sts = "0.32.0"
+rusoto_credential = "0.11.0"
 rust-ini = "0.12"

--- a/src/aws/assume_role.rs
+++ b/src/aws/assume_role.rs
@@ -1,6 +1,8 @@
-use rusoto_core::Region;
-use rusoto_sts::{AssumeRoleWithSAMLError, AssumeRoleWithSAMLRequest, AssumeRoleWithSAMLResponse,
-                 Sts, StsClient};
+use rusoto_core::{reactor::RequestDispatcher, Region};
+use rusoto_credential::StaticProvider;
+use rusoto_sts::{
+    AssumeRoleWithSAMLError, AssumeRoleWithSAMLRequest, AssumeRoleWithSAMLResponse, Sts, StsClient,
+};
 
 pub fn assume_role(
     arn: &str,
@@ -8,7 +10,11 @@ pub fn assume_role(
     saml_assertion: &str,
     session_duration: Option<i64>,
 ) -> Result<AssumeRoleWithSAMLResponse, AssumeRoleWithSAMLError> {
-    let c = StsClient::simple(Region::EuCentral1);
+    let c = StsClient::new(
+        RequestDispatcher::default(),
+        StaticProvider::new_minimal("UNSET".into(), "UNSET".into()),
+        Region::EuCentral1,
+    );
 
     c.assume_role_with_saml(&AssumeRoleWithSAMLRequest {
         role_arn: arn.into(),

--- a/src/aws/credentials.rs
+++ b/src/aws/credentials.rs
@@ -1,10 +1,17 @@
 use std::env;
+use std::fs::File;
 use std::path::PathBuf;
 
 use super::ini;
 
 pub fn load_credentials_file() -> Result<(ini::Ini, PathBuf), ini::ini::Error> {
     let filename = env::home_dir().unwrap().join(".aws").join("credentials");
+
+    if !filename.exists() {
+        File::create(&filename).expect(
+            "Could not create $HOME/.aws/credentials. Does the directory $HOME/.aws exist?",
+        );
+    }
 
     ini::Ini::load_from_file(&filename).map(|o| (o, filename))
 }

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,5 +1,5 @@
 name: saml2aws-auto
-version: "1.2.0"
+version: "1.2.1"
 author: Jan Christophersen <jan@ruken.pw>
 about: A simple to use management tool for multiple AWS account credentials when using Keycloak as Identity Provider
 settings:

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate ini;
 extern crate keyring;
 extern crate reqwest;
 extern crate rusoto_core;
+extern crate rusoto_credential;
 extern crate rusoto_sts;
 extern crate scraper;
 


### PR DESCRIPTION
We will now prepoluate the access key and secret key with some gibberish
as the assume_role_with_saml call does not need them